### PR TITLE
Fix: Ensure full page content is rendered server-side

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,11 +41,12 @@ interface AppProps {
 const queryClient = new QueryClient();
 
 const App = ({ Router = BrowserRouter }: AppProps) => {
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
   const [isChatbotLoaded, setIsChatbotLoaded] = useState(false);
 
   // Simulate initial loading
   useEffect(() => {
+    setIsLoading(true); // Show loading screen
     // Preload critical resources if needed
     const preloadResources = async () => {
       // You can add actual resource preloading here if needed
@@ -55,9 +56,9 @@ const App = ({ Router = BrowserRouter }: AppProps) => {
     preloadResources();
     // Loading state is managed by the LoadingScreen component
     const timer = setTimeout(() => {
-      setIsLoading(false);
-      setTimeout(() => setIsChatbotLoaded(true), 3000);
-    }, 2000);
+      setIsLoading(false); // Hide loading screen
+      setTimeout(() => setIsChatbotLoaded(true), 3000); // Existing logic for chatbot
+    }, 2000); // Existing delay
 
     return () => clearTimeout(timer);
   }, []);
@@ -70,7 +71,7 @@ const App = ({ Router = BrowserRouter }: AppProps) => {
         {isLoading && <LoadingScreen onLoadingComplete={() => setIsLoading(false)} />}
         <Router>
           <ScrollToTop />
-          {!isLoading && <Navbar />}
+          <Navbar />
           <main className="relative">
             <RouteTransition>
               <Routes>
@@ -102,15 +103,15 @@ const App = ({ Router = BrowserRouter }: AppProps) => {
             </RouteTransition>
           </main>
           <div className="footer-wrapper relative z-[45]">
-            {!isLoading && <Footer />}
+            <Footer />
           </div>
           {isChatbotLoaded && (
             <Suspense fallback={null}>
               <Chatbot />
             </Suspense>
           )}
-          {!isLoading && <FloatingProgressBar />}
-          {!isLoading && <SmoothCursor />}
+          <FloatingProgressBar />
+          <SmoothCursor />
         </Router>
       </TooltipProvider>
     </QueryClientProvider>


### PR DESCRIPTION
The application was previously configured such that the main content (Navbar, Footer, page-specific content) was hidden behind an `isLoading` state that was only set to `false` on the client-side after a delay. This resulted in the initial server-rendered HTML primarily containing a loading screen, not the actual page content.

This commit addresses the issue by:
1. Modifying `App.tsx` to initialize the `isLoading` state to `false`. This ensures that the main layout components (`Navbar`, `Footer`, etc.) are included in the server-side render output.
2. Adjusting the `useEffect` hook in `App.tsx` to manage the visibility of the `LoadingScreen` component purely on the client-side. The loading screen will now appear briefly after initial hydration as a client-side visual effect, rather than preventing the SSR of core content.

This change ensures that the HTML delivered by the server contains the meaningful page structure, improving SEO and perceived load times, and resolving the issue where you might not see the full HTML content in the initial response. Client-side hydration has been analyzed and is expected to work correctly with these changes.